### PR TITLE
Change imports relative path to absolute path

### DIFF
--- a/session/session_test.go
+++ b/session/session_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/TuSKan/go-sfdc"
-	"./credentials"
+	"github.com/TuSKan/go-sfdc/credentials"
 )
 
 func TestPasswordSessionRequest(t *testing.T) {

--- a/sobject/collections/collections_test.go
+++ b/sobject/collections/collections_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/TuSKan/go-sfdc"
 	"github.com/TuSKan/go-sfdc/session"
-	"./sobject"
+	"github.com/TuSKan/go-sfdc/sobject"
 )
 
 func Test_collection_send(t *testing.T) {

--- a/sobject/collections/delete_test.go
+++ b/sobject/collections/delete_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"./sobject"
+	"github.com/TuSKan/go-sfdc/sobject"
 
 	"github.com/TuSKan/go-sfdc"
 

--- a/sobject/collections/insert_test.go
+++ b/sobject/collections/insert_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/TuSKan/go-sfdc"
 	"github.com/TuSKan/go-sfdc/session"
-	"./sobject"
+	"github.com/TuSKan/go-sfdc/sobject"
 )
 
 type mockInserter struct {

--- a/sobject/collections/query_test.go
+++ b/sobject/collections/query_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/TuSKan/go-sfdc/session"
-	"./sobject"
+	"github.com/TuSKan/go-sfdc/sobject"
 )
 
 type mockQuery struct {

--- a/sobject/collections/update_test.go
+++ b/sobject/collections/update_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/TuSKan/go-sfdc"
 	"github.com/TuSKan/go-sfdc/session"
-	"./sobject"
+	"github.com/TuSKan/go-sfdc/sobject"
 )
 
 type mockUpdater struct {


### PR DESCRIPTION
Change imports to satisfy `go mod tidy`:
```
github.com/TuSKan/go-sfdc/session tested by
        github.com/TuSKan/go-sfdc/session.test imports
        ./credentials: "./credentials" is relative, but relative import paths are not supported in module mode
```